### PR TITLE
Allow context manager invocation to suppress output

### DIFF
--- a/statprof.py
+++ b/statprof.py
@@ -286,13 +286,14 @@ def reset(frequency=None):
 
 
 @contextmanager
-def profile():
+def profile(verbose=True):
     start()
     try:
         yield
     finally:
         stop()
-        display()
+        if verbose:
+            display()
 
 
 ###########################################################################


### PR DESCRIPTION
After realizing that the profiler can be used to sample several distinct sections of code, and adding an example for that to the docs, the actual code for it looked rather long and awkward:

``` python
import statprof

statprof.start()
try:
    my_questionable_function()
finally:
    statprof.stop()

uninteresting_code()

statprof.start()
try:
    my_other_questionable_function()
finally:
    statprof.stop()

statprof.display()
```

Since using the context manager is so much sweeter, I've added a parameter to it which stops the results from being printed every time. This change turns the above code into:

``` python
import statprof

with statprof.profile(verbose=False):
    my_questionable_function()

uninteresting_code()

with statprof.profile()
    my_other_questionable_function()
```

This shouldn't break anything, since when no parameter is passed, the behavior is the same as before. `verbose` might not be the best name for the parameter, so I'm open to suggestions for a better one.
